### PR TITLE
Add darwin arm64 to make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ compile:
 
 release:
 	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64
+	GOOS=darwin GOARCH=arm64 go build -o ./bin/${BINARY}_${VERSION}_darwin_arm64	
 	GOOS=freebsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_freebsd_386
 	GOOS=freebsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_freebsd_amd64
 	GOOS=freebsd GOARCH=arm go build -o ./bin/${BINARY}_${VERSION}_freebsd_arm


### PR DESCRIPTION
Hello,

Sorry if this is the incorrect place for this. 

It appears we're currently not building an M1 Mac compatible version of ASA currently. While Rosetta 2 is able to run Terraform, in my experience, it's a spin of the roulette wheel on if Terraform is going to fail or not. 

Below is a screenshot of the steps I took to build an Darwin ARM64 version of the TF Provider. As golang is pretty awesome, it seems to have "just built," but I cannot confirm if there are any other issues. 

![image](https://user-images.githubusercontent.com/60126045/166975384-daeb9881-7053-4436-abcb-ede7b1f75f5b.png)

I also ran "make install" and that seemed to be succesful.

```
~/code/asa/terraform-provider-oktapam (master*) » make install
go build -o terraform-provider-oktapam
mkdir -p ~/.terraform.d/plugins/hashicorp.com/okta/oktapam/0.1.0/darwin_arm64
mv terraform-provider-oktapam ~/.terraform.d/plugins/hashicorp.com/okta/oktapam/0.1.0/darwin_arm64
```