### PR TITLE
Security Review Fix: Log Warning on RSA-01 Usage

### DIFF
--- a/oktapam/resource_project.go
+++ b/oktapam/resource_project.go
@@ -91,7 +91,7 @@ func resourceProject() *schema.Resource {
 								diag := diag.Diagnostic{
 									Severity: diag.Warning,
 									Summary:  "deprecated value",
-									Detail:   "CERT_TYPE_RSA_01 is a deprecated key algorithm type and should only be used for compatibility purposes.  For new projects, please use a more current key algorithm",
+									Detail:   "CERT_TYPE_RSA_01 is a deprecated key algorithm type. This option should only be used to connect to legacy systems that cannot use newer SSH versions. If you do need to use CERT_TYPE_RSA_01, it is recommended to connect via a gateway with traffic forwarding. Otherwise, please use a more current key algorithm. ",
 								}
 								return append(diags, diag)
 							}


### PR DESCRIPTION
While the RSA-01 is technically allowed today, it seems probable the CA service will be fully rolled out across teams (existing and new). 

Review Issue: https://oktainc.atlassian.net/browse/OKTA-493084 