### PR TITLE
Security Review Fix: TestCase.Provider Deprecated, Switch to ProviderFactories

### DIFF
--- a/oktapam/data_source_gateway_setup_token_test.go
+++ b/oktapam/data_source_gateway_setup_token_test.go
@@ -22,7 +22,7 @@ func TestAccDatasourceGatewaySetupToken(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: createTestAccDatasourceGatewaySetupTokenInitConfig(description1, description2, labels),

--- a/oktapam/data_source_group_test.go
+++ b/oktapam/data_source_group_test.go
@@ -26,7 +26,7 @@ func TestAccDatasourceGroup(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: createTestAccDatasourceGroupInitConfig(groupNamePrefix),

--- a/oktapam/data_source_project_group_test.go
+++ b/oktapam/data_source_project_group_test.go
@@ -35,7 +35,7 @@ func TestAccDatasourceProjectGroup(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: createTestAccDatasourceProjectGroupInitConfig(projectName, group1Name, group2Name),

--- a/oktapam/data_source_project_test.go
+++ b/oktapam/data_source_project_test.go
@@ -28,7 +28,7 @@ func TestAccDatasourceProject(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: createTestAccDatasourceProjectCreateConfig(projectNamePrefix),

--- a/oktapam/data_source_server_enrollment_token_test.go
+++ b/oktapam/data_source_server_enrollment_token_test.go
@@ -15,7 +15,7 @@ func TestAccDatasourceServerEnrollmentToken(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:  func() { testAccPreCheck(t) },
-		Providers: testAccProviders,
+		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
 				Config: createTestAccDatasourceServerEnrollmentTokenInitConfig(projectName, description1, description2),

--- a/oktapam/provider_test.go
+++ b/oktapam/provider_test.go
@@ -18,13 +18,14 @@ func TestProvider(t *testing.T) {
 	}
 }
 
-var testAccProviders map[string]*schema.Provider
+var testAccProviders map[string]func() (*schema.Provider, error)
 var testAccProvider *schema.Provider
 
 func init() {
 	testAccProvider = Provider()
-	testAccProviders = map[string]*schema.Provider{
-		"oktapam": testAccProvider,
+	testAccProviders = map[string]func() (*schema.Provider, error){}
+	testAccProviders["oktapam"] = func() (*schema.Provider, error) {
+		return testAccProvider, nil
 	}
 }
 

--- a/oktapam/resource_gateway_setup_token_test.go
+++ b/oktapam/resource_gateway_setup_token_test.go
@@ -28,7 +28,7 @@ func TestAccGatewaySetupToken(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		ProviderFactories:    testAccProviders,
 		CheckDestroy: testAccGatewaySetupTokenCheckDestroy(setupToken),
 		Steps: []resource.TestStep{
 			{

--- a/oktapam/resource_group_test.go
+++ b/oktapam/resource_group_test.go
@@ -25,7 +25,7 @@ func TestAccGroup(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		ProviderFactories:    testAccProviders,
 		CheckDestroy: testAccGroupCheckDestroy(groupName),
 		Steps: []resource.TestStep{
 			{

--- a/oktapam/resource_project_group_test.go
+++ b/oktapam/resource_project_group_test.go
@@ -32,7 +32,7 @@ func TestAccProjectGroup(t *testing.T) {
 	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		ProviderFactories:    testAccProviders,
 		CheckDestroy: testAccProjectGroupCheckDestroy(initialProjectGroup),
 		Steps: []resource.TestStep{
 			{

--- a/oktapam/resource_project_test.go
+++ b/oktapam/resource_project_test.go
@@ -40,7 +40,7 @@ func TestAccProject(t *testing.T) {
 	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		ProviderFactories:    testAccProviders,
 		CheckDestroy: testAccProjectCheckDestroy(projectName),
 		Steps: []resource.TestStep{
 			{

--- a/oktapam/resource_server_enrollment_token_test.go
+++ b/oktapam/resource_server_enrollment_token_test.go
@@ -21,7 +21,7 @@ func TestAccServerEnrollmentToken(t *testing.T) {
 	}
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
-		Providers:    testAccProviders,
+		ProviderFactories:    testAccProviders,
 		CheckDestroy: testAccServerEnrollmentTokenCheckDestroy(enrollmentToken),
 		Steps: []resource.TestStep{
 			{


### PR DESCRIPTION
`Providers` were deprecated and needed to be replaced with `ProviderFactories`.

Review Issue: https://oktainc.atlassian.net/browse/OKTA-493190 