### PR TITLE
only notify on slack when failure occurs on master or tag

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -56,7 +56,7 @@ jobs:
     name: Notify Slack on Failure
     runs-on: ubuntu-latest
     needs: [check1, check2, check3, check4]
-    if: failure() && github.repository == 'okta/terraform-provider-oktapam'
+    if: failure() && github.repository == 'okta/terraform-provider-oktapam' && ((github.ref_type == 'branch' && github.ref_name == 'master') || github.ref_type == 'tag')
     steps:
       - name: Check out repository code
         uses: actions/checkout@v2


### PR DESCRIPTION
Only notify on slack when failures occur on the master branch or when applied to a tag.  This keeps it consistent with notifications of build failures for platform.  