### PR TITLE
Move Acceptance Testing to Trex

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,6 +41,7 @@ jobs:
           OKTAPAM_SECRET: ${{ secrets.OKTA_499446_OKTAPAM_SECRET }}
           OKTAPAM_KEY: ${{ secrets.OKTA_499446_OKTAPAM_KEY }}
           OKTAPAM_TEAM: ${{ secrets.OKTA_499446_OKTAPAM_TEAM }}
+          OKTAPAM_API_HOST: ${{ secrets.OKTA_499446_OKTAPAM_API_HOST }}
       - run: echo "🍏 This job's status is ${{ job.status }}."
   check4:
     name: Doc Generation

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -33,6 +33,7 @@ ci-acceptance-test: ci-container
 		-e OKTAPAM_KEY \
 		-e OKTAPAM_SECRET \
 		-e OKTAPAM_TEAM \
+		-e OKTAPAM_API_HOST \
 		-v "$(CURDIR)/build/ci-output:/output" `cat ./build/ci-output/container.txt` /usr/bin/make -C ${SRC_DIR} testacc
 
 .PHONY: ci-compile

--- a/oktapam/client/okta_pam_client.go
+++ b/oktapam/client/okta_pam_client.go
@@ -16,7 +16,7 @@ import (
 	"github.com/okta/terraform-provider-oktapam/oktapam/version"
 )
 
-const OKTAPAM_TRUSTED_DOMAINS = "scaleft.com,okta.com"
+const OKTAPAM_TRUSTED_DOMAINS = "scaleft.com,scaleft.io,okta.com"
 const TRUSTED_DOMAIN_OVERRIDE_ENV_VAR = "OKTAPAM_TRUSTED_DOMAIN_OVERRIDE"
 
 var terraformUserAgent = "terraform_provider_oktapam/" + version.Version


### PR DESCRIPTION
Catch regressions before they go out to production. 

The name of the ASA testing team is the same but the API_HOST points to https://app.trex.scaleft.io/