### PR TITLE
Updated example to refer to gateway setup token resources

### DIFF
--- a/examples/oktapam_ad_connection/Readme.md
+++ b/examples/oktapam_ad_connection/Readme.md
@@ -7,4 +7,4 @@ To run the example:
 #### Prerequisites
 * Create service user required to use the provider [here](../../README.md#using-the-provider).
 * Update the variables.tf OR provide overrides.
-* Currently, OktaPAM terraform provider doesn't support creating gateway. Follow instructions at [Setup Gateway](https://help.okta.com/asa/en-us/Content/Topics/Adv_Server_Access/docs/ad-gateways.htm) to create one before creating AD Connections and Tasks.
+* To automate gateway creation, use the gateway_setup_token resource to create a new gateway setup token or use the gateway_setup_token data source to retrieve previously created gateway setup tokens. Alternatively, follow the instructions at [Setup Gateway](https://help.okta.com/asa/en-us/Content/Topics/Adv_Server_Access/docs/ad-gateways.htm) to create one before creating AD Connections and Tasks.


### PR DESCRIPTION
Update to note that the Okta PAM provider does support creating gateway tokens.