### PR TITLE
Update Import GPG Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
       -
         name: Import GPG key
         id: import_gpg
-        uses: hashicorp/ghaction-import-gpg@v2.1.0
+        uses: crazy-max/ghaction-import-gpg@v5
         env:
           # These secrets will need to be configured for the repository:
           GPG_PRIVATE_KEY: ${{ secrets.OKTA_520419_GPG_PRIVATE_KEY }}


### PR DESCRIPTION
Use the same [action](https://github.com/crazy-max/ghaction-import-gpg) that Okta's terraform provider [uses](https://github.com/okta/terraform-provider-okta/blob/master/.github/workflows/release.yml#L36). 