### PR TITLE
Fix Release Action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,10 @@ jobs:
         name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5
-        env:
+        with:
           # These secrets will need to be configured for the repository:
-          GPG_PRIVATE_KEY: ${{ secrets.OKTA_520419_GPG_PRIVATE_KEY }}
-          PASSPHRASE: ${{ secrets.OKTA_520419_PASSPHRASE }}
+          gpg_private_key: ${{ secrets.OKTA_520419_GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.OKTA_520419_PASSPHRASE }}
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.0.0

--- a/oktapam/resource_ad_certificate_request_test.go
+++ b/oktapam/resource_ad_certificate_request_test.go
@@ -3,8 +3,9 @@ package oktapam
 import (
 	"context"
 	"fmt"
-	"github.com/okta/terraform-provider-oktapam/oktapam/constants/typed_strings"
 	"testing"
+
+	"github.com/okta/terraform-provider-oktapam/oktapam/constants/typed_strings"
 
 	"github.com/okta/terraform-provider-oktapam/oktapam/logging"
 	"github.com/okta/terraform-provider-oktapam/oktapam/utils"
@@ -17,7 +18,7 @@ import (
 
 const (
 	csrStatusCreated = "request_created"
-	certStatusValid	 = "valid"
+	certStatusValid  = "valid"
 )
 
 func TestAccADCertificateRequest_CSR(t *testing.T) {


### PR DESCRIPTION
Overlooked the fact that the new import GPG action uses slightly different notation for defining the environment variables: https://github.com/okta/terraform-provider-okta/blob/master/.github/workflows/release.yml#L38 