### PR TITLE
Updates terraform binary provisioning

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,13 +22,6 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Get Terraform CLI Version
-        id: vars
-        run: echo ::set-output name=tf-version::$(cat .terraform-version)
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v2
-        with:
-          terraform_version: ${{ steps.vars.outputs.tf-version }}
       - name: Run unit tests
         run: |
           ./scripts/ci-tests.sh
@@ -48,6 +41,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ steps.vars.outputs.tf-version }}
+          terraform_wrapper: false
       - name: Run unit tests
         run: |
           ./scripts/ci-acceptance-tests.sh

--- a/.github/workflows/tag-checks.yml
+++ b/.github/workflows/tag-checks.yml
@@ -34,6 +34,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: ${{ steps.vars.outputs.tf-version }}
+          terraform_wrapper: false
       - name: Run unit tests
         run: |
           ./scripts/ci-acceptance-tests.sh

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -34,6 +34,9 @@ ci-acceptance-test: ci-container
 		-e OKTAPAM_SECRET \
 		-e OKTAPAM_TEAM \
 		-e OKTAPAM_API_HOST \
+		-e TF_ACC_TERRAFORM_PATH=/usr/local/bin/terraform \
+		-e TF_ACC_TERRAFORM_VERSION \
+		-v ${TF_ACC_TERRAFORM_PATH}:/usr/local/bin/terraform \
 		-v "$(CURDIR)/build/ci-output:/output" `cat ./build/ci-output/container.txt` /usr/bin/make -C ${SRC_DIR} testacc
 
 .PHONY: ci-compile
@@ -52,6 +55,7 @@ ci-check-generate: ci-container
 		-e BUILDKITE_BUILD_NUMBER \
 		-e BUILDKITE_PIPELINE_SLUG \
 		-e BUILDKITE_JOB_ID \
+		-e TF_ACC_TERRAFORM_PATH \
 		-v "$(CURDIR)/build/ci-output:/output" `cat ./build/ci-output/container.txt` /usr/bin/make -C ${SRC_DIR} check-generate
 
 .PHONY: all ci-compile ci-test ci-acceptance-test ci-check-generate

--- a/scripts/ci-acceptance-tests.sh
+++ b/scripts/ci-acceptance-tests.sh
@@ -7,4 +7,12 @@ if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
 
 cd "${DIR}/.."
 
+TF_BIN=$(which terraform)
+if [[ -x "${TF_BIN}" ]]; then
+    echo "found terraform at ${TF_BIN}, setting TF_ACC_TERRAFORM_PATH=${TF_BIN}"
+    # This path needs to be added to the Docker run command
+    export TF_ACC_TERRAFORM_PATH="${TF_BIN}"
+    export TF_ACC_TERRAFORM_VERSION="$(cat .terraform-version)"
+fi
+
 make -f Makefile.ci ci-acceptance-test


### PR DESCRIPTION
- Updates the terraform bin setup script to pull down the correct
  version.
- Provides the local terraform binary to the running Docker container
  with the integration tests.
- Turns off usage of the terraform wrapper since we don't need it and
  adds extra dependencies.