### PR TITLE
Adds .terraform-version for tag check

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -57,6 +57,16 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
+      - name: Check out repository code
+        uses: actions/checkout@v3
+      - name: Get Terraform CLI Version
+        id: vars
+        run: echo ::set-output name=tf-version::$(cat .terraform-version)
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: ${{ steps.vars.outputs.tf-version }}
+          terraform_wrapper: false
       - name: Run unit tests
         run: |
           ./scripts/ci-check-generated.sh

--- a/.github/workflows/tag-checks.yml
+++ b/.github/workflows/tag-checks.yml
@@ -11,6 +11,8 @@ jobs:
     if: github.repository == 'okta/terraform-provider-oktapam' || github.event.label.name == 'run-tag-tests'
     runs-on: ubuntu-latest
     strategy:
+      # 409 with resource already exist errors occurred when attempting to run all of these at the same time so we limit to half
+      max-parallel: 6
       matrix:
         # On version change, add new version here
         # On breaking changes, by definition past version mays no longer work. Wipe version at that point.
@@ -26,7 +28,7 @@ jobs:
       - name: Check out most recent files for testing purposes
         run: |
           git fetch origin master
-          git checkout origin/master Makefile.ci oktapam/client/okta_pam_client.go
+          git checkout origin/master Makefile.ci oktapam/client/okta_pam_client.go .terraform-version scripts/ci-acceptance-tests.sh
       - name: Get Terraform CLI Version
         id: vars
         run: echo ::set-output name=tf-version::$(cat .terraform-version)

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -55,7 +55,9 @@ ci-check-generate: ci-container
 		-e BUILDKITE_BUILD_NUMBER \
 		-e BUILDKITE_PIPELINE_SLUG \
 		-e BUILDKITE_JOB_ID \
-		-e TF_ACC_TERRAFORM_PATH \
+		-e TF_ACC_TERRAFORM_PATH=/usr/local/bin/terraform \
+		-e TF_ACC_TERRAFORM_VERSION \
+		-v ${TF_ACC_TERRAFORM_PATH}:/usr/local/bin/terraform \
 		-v "$(CURDIR)/build/ci-output:/output" `cat ./build/ci-output/container.txt` /usr/bin/make -C ${SRC_DIR} check-generate
 
 .PHONY: all ci-compile ci-test ci-acceptance-test ci-check-generate

--- a/scripts/ci-acceptance-tests.sh
+++ b/scripts/ci-acceptance-tests.sh
@@ -7,6 +7,10 @@ if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
 
 cd "${DIR}/.."
 
+set -x
+
+export TF_ACC_TERRAFORM_VERSION=""
+
 TF_BIN=$(which terraform)
 if [[ -x "${TF_BIN}" ]]; then
     echo "found terraform at ${TF_BIN}, setting TF_ACC_TERRAFORM_PATH=${TF_BIN}"

--- a/scripts/ci-check-generated.sh
+++ b/scripts/ci-check-generated.sh
@@ -7,4 +7,11 @@ if [[ ! -d "$DIR" ]]; then DIR="$PWD"; fi
 
 cd "${DIR}/.."
 
+if [[ -x "${TF_BIN}" ]]; then
+    echo "found terraform at ${TF_BIN}, setting TF_ACC_TERRAFORM_PATH=${TF_BIN}"
+    # This path needs to be added to the Docker run command
+    export TF_ACC_TERRAFORM_PATH="${TF_BIN}"
+    export TF_ACC_TERRAFORM_VERSION="$(cat .terraform-version)"
+fi
+
 make -f Makefile.ci ci-check-generate


### PR DESCRIPTION
- Currently the .terraform-version doesn't exist in the old tagged
  versions of the code so this part of the CI pipeline fails. If we
  checkout the lastest .terraform-version file we can test with out
  latest approved version of terraform.