### PR TITLE
Fix ProjectGroup server_selectors Behavior

### DIFF
--- a/oktapam/client/project_group.go
+++ b/oktapam/client/project_group.go
@@ -24,7 +24,7 @@ type ProjectGroup struct {
 	CreateServerGroup bool    `json:"create_server_group"`
 	ServerAccess      bool    `json:"server_access"`
 	ServerAdmin       bool    `json:"server_admin"`
-	ServersSelector   string  `json:"servers_selector,omitempty"`
+	ServersSelector   *string `json:"servers_selector,omitempty"`
 }
 
 func ProjectGroupFromMap(m map[string]interface{}) (*ProjectGroup, error) {
@@ -67,7 +67,7 @@ func ProjectGroupFromMap(m map[string]interface{}) (*ProjectGroup, error) {
 				return nil, err
 			}
 
-			p.ServersSelector = serversSelectorString
+			p.ServersSelector = &serversSelectorString
 		default:
 			return nil, fmt.Errorf("uknown key: %s", k)
 		}
@@ -136,15 +136,12 @@ func (p *ProjectGroup) ToResourceMap() (map[string]interface{}, error) {
 	}
 	m[attributes.ServerAccess] = p.ServerAccess
 	m[attributes.ServerAdmin] = p.ServerAdmin
-	if p.ServersSelector != "" {
-		selectorsMap, err := parseServersSelectorString(p.ServersSelector)
+	if p.ServersSelector != nil {
+		selectorsMap, err := parseServersSelectorString(*p.ServersSelector)
 		if err != nil {
 			return nil, err
 		}
 		m[attributes.ServersSelector] = selectorsMap
-	} else {
-		var ss map[string]interface{}
-		m[attributes.ServersSelector] = ss
 	}
 
 	return m, nil

--- a/oktapam/client/project_group.go
+++ b/oktapam/client/project_group.go
@@ -142,6 +142,8 @@ func (p *ProjectGroup) ToResourceMap() (map[string]interface{}, error) {
 			return nil, err
 		}
 		m[attributes.ServersSelector] = selectorsMap
+	} else {
+		m[attributes.ServersSelector] = ""
 	}
 
 	return m, nil

--- a/oktapam/client/project_group.go
+++ b/oktapam/client/project_group.go
@@ -143,7 +143,8 @@ func (p *ProjectGroup) ToResourceMap() (map[string]interface{}, error) {
 		}
 		m[attributes.ServersSelector] = selectorsMap
 	} else {
-		m[attributes.ServersSelector] = ""
+		var ss map[string]interface{}
+		m[attributes.ServersSelector] = ss
 	}
 
 	return m, nil

--- a/oktapam/constants/attributes/attributes.go
+++ b/oktapam/constants/attributes/attributes.go
@@ -74,7 +74,7 @@ const (
 	OrganizationalUnit               = "organizational_unit"
 	OSAttribute                      = "os_attribute"
 	ProjectGroups                    = "project_groups"
-	ProjectID						 = "project_id"
+	ProjectID                        = "project_id"
 	ProjectName                      = "project_name"
 	ProjectNames                     = "project_names"
 	Projects                         = "projects"

--- a/oktapam/data_source_gateway_setup_token_test.go
+++ b/oktapam/data_source_gateway_setup_token_test.go
@@ -61,7 +61,7 @@ func checkResourcesEqual(resourceName1 string, resourceName2 string) resource.Te
 
 		comparison := pretty.Compare(resource1.Primary.Attributes, resource2.Primary.Attributes)
 		if comparison != "" {
-			return fmt.Errorf("resources are not equal")
+			return fmt.Errorf("resources are not equal: %s", comparison)
 		}
 		return nil
 	}

--- a/oktapam/resource_project_group.go
+++ b/oktapam/resource_project_group.go
@@ -120,7 +120,7 @@ func resourceProjectGroupCreate(ctx context.Context, d *schema.ResourceData, m i
 		ServerAccess:      serverAccess,
 		ServerAdmin:       serverAdmin,
 		CreateServerGroup: createServerGroup,
-		ServersSelector:   serversSelectorString,
+		ServersSelector:   &serversSelectorString,
 	}
 
 	err = c.CreateProjectGroup(ctx, projectGroup)


### PR DESCRIPTION
When `server_selectors` value is updated in the dashboard UI there are three cases to consider, and one of the three cases is failing. 

This works correctly for:
- Config: Value “A”, Actual: Value “B”, Apply action: “B” > “A”
- Config: None, Actual: Value “B”, Apply action: “B” > null

However, this scenario does not work correctly:
- Config: Value “A”, Actual: None, Apply action: N/A

`ProjectGroup.ToResourceMap()` skipped `server_selectors` if it was empty. I suspect that if the value is omitted, Terraform retains the current value of that attribute. Now it'll be set if empty, and the Terraform state should be updated in that third case. 