### PR TITLE
Fix ssh_certificate_type not set on project update

### DIFF
--- a/oktapam/resource_project.go
+++ b/oktapam/resource_project.go
@@ -237,6 +237,7 @@ func resourceProjectUpdate(ctx context.Context, d *schema.ResourceData, m interf
 		attributes.SSHSessionRecording,
 		attributes.GatewaySelector,
 		attributes.UserOnDemandPeriod,
+		attributes.SSHCertificateType,
 	}
 
 	for _, attribute := range changeableAttributes {

--- a/oktapam/resource_project_test.go
+++ b/oktapam/resource_project_test.go
@@ -39,7 +39,7 @@ func TestAccProject(t *testing.T) {
 		RDPSessionRecording:    utils.AsBoolPtrZero(true, true),
 		SSHSessionRecording:    utils.AsBoolPtrZero(true, true),
 		GatewaySelector:        utils.AsStringPtr("env=test"),
-		SSHCertificateType:     utils.AsStringPtr("CERT_TYPE_ED25519_01"),
+		SSHCertificateType:     utils.AsStringPtr("CERT_TYPE_RSA_01"),
 		UserOnDemandPeriod:     utils.AsIntPtr(10),
 	}
 	resource.Test(t, resource.TestCase{
@@ -82,7 +82,7 @@ func TestAccProject(t *testing.T) {
 						resourceName, attributes.NextUnixGID, "63400",
 					),
 					resource.TestCheckResourceAttr(
-						resourceName, attributes.SSHCertificateType, "CERT_TYPE_ED25519_01",
+						resourceName, attributes.SSHCertificateType, "CERT_TYPE_RSA_01",
 					),
 					resource.TestCheckResourceAttr(
 						resourceName, attributes.UserOnDemandPeriod, "10",
@@ -168,7 +168,7 @@ resource "oktapam_project" "test_project" {
 	rdp_session_recording     = true
 	ssh_session_recording     = true
 	gateway_selector          = "env=test"
-	ssh_certificate_type      = "CERT_TYPE_ED25519_01"
+	ssh_certificate_type      = "CERT_TYPE_RSA_01"
 	user_on_demand_period     = 10
 }`
 


### PR DESCRIPTION
## Issue

Currently when updating a project, changing the SSH Certificate Type used by the project results in a plan that
appears to change the certificate type, but a subsequent apply does change this attribute on the project. 
This is verifiable in ASA console, and by running a subsequent call to `terraform plan`. 

Seeing as this attribute is changeable in the console, I believe it makes sense to be able to do so from the provider as well.

## Change Summary 

Adds SSHCertificateType to the list of attributes that are modifyable during a project update.

Specifically:

- Adds missing `attributes.SSHCertificateType` to the slice of `changeableAttributes` in `resourceProjectUpdate` function
- Updates test cases to account for a change in certificate type

## Notes

Verified that all acceptance tests pass when run against my dev tenant (with the exception of user tests, which have the tenant/team hardcoded)

I chose `CERT_TYPE_RSA_01` when updating the test cases, but I'm sure that could be changed to a different cert type if preferred.