### PR TITLE
OKTA-541126 - set the default create_server_users value to be true

### DIFF
--- a/oktapam/resource_project.go
+++ b/oktapam/resource_project.go
@@ -55,7 +55,7 @@ func resourceProject() *schema.Resource {
 			attributes.CreateServerUsers: {
 				Type:        schema.TypeBool,
 				Optional:    true,
-				Default:     false,
+				Default:     true,
 				Description: descriptions.CreateServerUsers,
 			},
 			attributes.DeletedAt: {

--- a/oktapam/resource_project_test.go
+++ b/oktapam/resource_project_test.go
@@ -21,7 +21,7 @@ func TestAccProject(t *testing.T) {
 		Name:                   &projectName,
 		NextUnixUID:            utils.AsIntPtr(60120),
 		NextUnixGID:            utils.AsIntPtr(63020),
-		CreateServerUsers:      utils.AsBoolPtrZero(false, true),
+		CreateServerUsers:      utils.AsBoolPtrZero(true, true),
 		ForwardTraffic:         utils.AsBoolPtrZero(false, true),
 		RequirePreAuthForCreds: utils.AsBoolPtrZero(false, true),
 		RDPSessionRecording:    utils.AsBoolPtrZero(false, true),


### PR DESCRIPTION
The ASA UI currently sets the `create_server_users` value to be true as a default, so we should be in line with that.  The setting of false does not allow for us to manage the life cycle of accounts on the server, so it is an important one to respect the default of true.  