### PR TITLE
Remove Old Tags With Failing Test

### DIFF
--- a/.github/workflows/tag-checks.yml
+++ b/.github/workflows/tag-checks.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         # On version change, add new version here
         # On breaking changes, by definition past version mays no longer work. Remove previous versions from the github action.
-        tag: [v0.3.0, v0.3.1]
+        tag: []
       fail-fast: false
     steps:
       - name: Check out repository code of tag


### PR DESCRIPTION
The tag test is failing periodically because of a flakey test that existed at those versions. I'm removing those versions from the tag test. 