### PR TITLE
Add Retry to Failed Acceptance Tests 

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -50,6 +50,15 @@ jobs:
           OKTAPAM_KEY: ${{ secrets.OKTA_499446_OKTAPAM_KEY }}
           OKTAPAM_TEAM: ${{ secrets.OKTA_499446_OKTAPAM_TEAM }}
           OKTAPAM_API_HOST: ${{ secrets.OKTA_499446_OKTAPAM_API_HOST }}
+      - name: If the acceptance tests fail, retry. Intended for failed locks and dependency download timeouts.
+          if: failure()
+          run: |
+            ./scripts/ci-acceptance-tests.sh
+          env:
+            OKTAPAM_SECRET: ${{ secrets.OKTA_499446_OKTAPAM_SECRET }}
+            OKTAPAM_KEY: ${{ secrets.OKTA_499446_OKTAPAM_KEY }}
+            OKTAPAM_TEAM: ${{ secrets.OKTA_499446_OKTAPAM_TEAM }}
+            OKTAPAM_API_HOST: ${{ secrets.OKTA_499446_OKTAPAM_API_HOST }}
       - run: echo "🍏 This job's status is ${{ job.status }}."
   check4:
     name: Doc Generation


### PR DESCRIPTION
There are at least two common classes of non-deterministic acceptance test failures: dependency download timeouts and failed locks (from tests being run in parallel). 

The intention of a retry is to reduce false positives.   