### PR TITLE
Fix certificate request resource

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,7 +51,7 @@ jobs:
           OKTAPAM_TEAM: ${{ secrets.OKTA_499446_OKTAPAM_TEAM }}
           OKTAPAM_API_HOST: ${{ secrets.OKTA_499446_OKTAPAM_API_HOST }}
       - name: If the acceptance tests fail, retry. Intended for failed locks and dependency download timeouts.
-          if: failure()
+          if: ${{ failure() }}
           run: |
             ./scripts/ci-acceptance-tests.sh
           env:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,14 +51,14 @@ jobs:
           OKTAPAM_TEAM: ${{ secrets.OKTA_499446_OKTAPAM_TEAM }}
           OKTAPAM_API_HOST: ${{ secrets.OKTA_499446_OKTAPAM_API_HOST }}
       - name: If the acceptance tests fail, retry. Intended for failed locks and dependency download timeouts.
-          if: ${{ failure() }}
-          run: |
-            ./scripts/ci-acceptance-tests.sh
-          env:
-            OKTAPAM_SECRET: ${{ secrets.OKTA_499446_OKTAPAM_SECRET }}
-            OKTAPAM_KEY: ${{ secrets.OKTA_499446_OKTAPAM_KEY }}
-            OKTAPAM_TEAM: ${{ secrets.OKTA_499446_OKTAPAM_TEAM }}
-            OKTAPAM_API_HOST: ${{ secrets.OKTA_499446_OKTAPAM_API_HOST }}
+        if: failure()
+        run: |
+          ./scripts/ci-acceptance-tests.sh
+        env:
+          OKTAPAM_SECRET: ${{ secrets.OKTA_499446_OKTAPAM_SECRET }}
+          OKTAPAM_KEY: ${{ secrets.OKTA_499446_OKTAPAM_KEY }}
+          OKTAPAM_TEAM: ${{ secrets.OKTA_499446_OKTAPAM_TEAM }}
+          OKTAPAM_API_HOST: ${{ secrets.OKTA_499446_OKTAPAM_API_HOST }}
       - run: echo "🍏 This job's status is ${{ job.status }}."
   check4:
     name: Doc Generation


### PR DESCRIPTION

AD Certificate Request is reporting drift while doing terraform apply without making any changes. Issue was resource has certificate details (Organization, OrganizationalUnit, Province, Country, TTLDays) which are required while creating resource but read api doesn't return them back. 