### PR TITLE
Removed setting run_test attribute

### DIFF
--- a/oktapam/client/ad_connection.go
+++ b/oktapam/client/ad_connection.go
@@ -381,6 +381,11 @@ func (p ListADConnectionsParameters) toQueryParametersMap() map[string]string {
 	return m
 }
 
+// ToResourceMap Convert API Object to flat map for saving in terraform state
+// API always return false for attribute run_test, regardless of what is passed while creating/updating the resource.
+// Don't set Run_Test attribute  while reading the resource back, to avoid tf showing drift during plan while comparing
+// it with the previous state (if run_test was set to 'true' initially). In this case, whatever value is coming as
+// part of tf config (proposed state) will be set in the tf state.
 func (adUserSyncTaskSettings ADUserSyncTaskSettings) ToResourceMap() map[string]interface{} {
 	m := make(map[string]interface{})
 

--- a/oktapam/client/ad_connection.go
+++ b/oktapam/client/ad_connection.go
@@ -411,9 +411,6 @@ func (adUserSyncTaskSettings ADUserSyncTaskSettings) ToResourceMap() map[string]
 	if adUserSyncTaskSettings.IsActive != nil {
 		m[attributes.IsActive] = *adUserSyncTaskSettings.IsActive
 	}
-	if adUserSyncTaskSettings.RunTest != nil {
-		m[attributes.RunTest] = *adUserSyncTaskSettings.RunTest
-	}
 
 	return m
 }

--- a/oktapam/data_source_ad_user_sync_task_settings_test.go
+++ b/oktapam/data_source_ad_user_sync_task_settings_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/okta/terraform-provider-oktapam/oktapam/constants/attributes"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/okta/terraform-provider-oktapam/oktapam/logging"
 )
@@ -31,8 +33,19 @@ func TestAccDataSourceADUserSyncTaskSettings(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config: createTestAccDataSourceADUserSyncTaskSettingsInitConfig(preConfig, adUserSyncTaskName),
-				Check: resource.ComposeAggregateTestCheckFunc(checkResourcesEqual(
-					adUserSyncTaskSettingsResourceName, dataSourceResourceName),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair(dataSourceResourceName, attributes.Name,
+					adUserSyncTaskSettingsResourceName, attributes.Name),
+					resource.TestCheckResourceAttrPair(dataSourceResourceName, attributes.Frequency,
+						adUserSyncTaskSettingsResourceName, attributes.Frequency),
+					resource.TestCheckResourceAttrPair(dataSourceResourceName, attributes.SIDField,
+						adUserSyncTaskSettingsResourceName, attributes.SIDField),
+					resource.TestCheckResourceAttrPair(dataSourceResourceName, attributes.UPNField,
+						adUserSyncTaskSettingsResourceName, attributes.UPNField),
+					resource.TestCheckResourceAttrPair(dataSourceResourceName, attributes.BaseDN,
+						adUserSyncTaskSettingsResourceName, attributes.BaseDN),
+					resource.TestCheckResourceAttrPair(dataSourceResourceName, attributes.LDAPQueryFilter,
+						adUserSyncTaskSettingsResourceName, attributes.LDAPQueryFilter),
 				),
 			},
 		},

--- a/oktapam/resource_ad_task_settings.go
+++ b/oktapam/resource_ad_task_settings.go
@@ -340,7 +340,11 @@ func expandADRuleAssignments(tfList []any) []*client.ADRuleAssignment {
 	return apiObjects
 }
 
-//Convert API Object to flat map for saving in terraform state
+// flattenADTaskSettings Convert API Object to flat map for saving in terraform state
+// API always return false for attribute run_test, regardless of what is passed while creating/updating the resource.
+// Don't set Run_Test attribute  while reading the resource back, to avoid tf showing drift during plan while comparing
+// it with the previous state (if run_test was set to 'true' initially). In this case, whatever value is coming as
+// part of tf config (proposed state) will be set in the tf state.
 func flattenADTaskSettings(taskSettings *client.ADTaskSettings) map[string]any {
 	m := make(map[string]any, 2)
 

--- a/oktapam/resource_ad_task_settings.go
+++ b/oktapam/resource_ad_task_settings.go
@@ -58,8 +58,8 @@ func resourceADTaskSettings() *schema.Resource {
 			},
 			attributes.RunTest: {
 				Type:        schema.TypeBool,
+				Default:     false,
 				Optional:    true,
-				Computed:    true,
 				Description: descriptions.ADTaskRunTest,
 			},
 			attributes.StartHourUTC: {
@@ -355,9 +355,6 @@ func flattenADTaskSettings(taskSettings *client.ADTaskSettings) map[string]any {
 	}
 	if taskSettings.IsActive != nil {
 		m[attributes.IsActive] = *taskSettings.IsActive
-	}
-	if taskSettings.RunTest != nil {
-		m[attributes.RunTest] = *taskSettings.RunTest
 	}
 	if taskSettings.StartHourUTC != nil {
 		m[attributes.StartHourUTC] = *taskSettings.StartHourUTC

--- a/oktapam/resource_ad_task_settings_test.go
+++ b/oktapam/resource_ad_task_settings_test.go
@@ -52,6 +52,7 @@ func TestAccADTaskSettings(t *testing.T) {
 					//Check if there is exactly one ad rule assignment
 					//.#: Number of elements in list or set
 					resource.TestCheckResourceAttr(adTaskResourceName, fmt.Sprintf("%s.#", attributes.ADRuleAssignments), "1"),
+					resource.TestCheckResourceAttr(adTaskResourceName, attributes.RunTest, "true"),
 				),
 			},
 			{
@@ -99,6 +100,7 @@ func TestAccADTaskSettings(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccADTaskSettingsImportStateId(adTaskResourceName),
+				ImportStateVerifyIgnore: []string{attributes.RunTest},
 			},
 		},
 	})
@@ -200,6 +202,7 @@ resource "oktapam_ad_task_settings" "test_acc_ad_task_settings" {
    project_id        = oktapam_project.test_acc_project.id
    priority          = 1
  }
+ run_test = true
 }
 `
 

--- a/oktapam/resource_ad_user_sync_task_settings_test.go
+++ b/oktapam/resource_ad_user_sync_task_settings_test.go
@@ -79,6 +79,7 @@ func TestAccADUserSyncTaskSettings(t *testing.T) {
 				ImportState:       true,
 				ImportStateVerify: true,
 				ImportStateIdFunc: testAccADUserSyncTaskSettingsImportStateId(adUserSyncTaskSettingsResourceName1),
+				ImportStateVerifyIgnore: []string{attributes.RunTest},
 			},
 		},
 	})


### PR DESCRIPTION
Don't set Run_Test attribute for AD Task Settings resource while reading the resource back. API always return false for attribute run_test, regardless of what was passed while creating/updating tasks settings resource. If we set this attribute while reading back, then tf going to show drift during plan while comparing it with the previous state (if run_test was set to 'true" initially).

To avoid this, put the solution:
1. While reading resource back, ignore setting run_test. Whatever value is coming as part of tf config (proposed state) will be set in the state and passed to api too while creating/updating resource.
2. If only attribute updated is run_test, don't do anything and just update the provided value in state.