### PR TITLE
Update to run checks everyday after 5 PM PST

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,7 +3,7 @@ on:
   push:
   schedule:
     # Run every hour. Uses POSIX cron syntax
-    - cron: "0 */1 * * *"
+    - cron: "0 1 * * *"
 
 jobs:
   check1:


### PR DESCRIPTION
Currently, checks run every hour and during deployment window tests failed due to service unavailability. Updating schedule to run just once every day after 5 PM PST. Don't think running every hour is really needed here.