### PR TITLE
use clean instead of rm-dist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v3.0.0
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           # GitHub sets this automatically


### PR DESCRIPTION
go-releaser removed `rm-dist` in favor of `clean`, so use `clean' now

https://goreleaser.com/deprecations/#-rm-dist