### PR TITLE
pin version for config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3.0.0
         with:
-          version: latest
+          version: 2
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,28 +21,27 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Unshallow
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: 1.21
       -
         name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v5
+        uses: crazy-max/ghaction-import-gpg@v6
         with:
           # These secrets will need to be configured for the repository:
           gpg_private_key: ${{ secrets.OKTA_520419_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.OKTA_520419_PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v3.0.0
+        uses: goreleaser/goreleaser-action@v6.0.0
         with:
-          version: 2
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}


### PR DESCRIPTION
Pin the version for the config to be version two based on help article here: 

https://goreleaser.com/errors/version/

This was seen in the following run: https://github.com/okta/terraform-provider-oktapam/actions/runs/11686112558/job/32541126595#step:6:20